### PR TITLE
fix: output correct version info to the console

### DIFF
--- a/src/DotBump/Program.cs
+++ b/src/DotBump/Program.cs
@@ -23,7 +23,7 @@ Log.Debug("Configuring app");
 
 var commandApp = new CommandApp();
 
-AnsiConsole.WriteLine($"Initializing DotBump version {versionInfo.ProductVersion}");
+AnsiConsole.WriteLine($"Initializing DotBump version {versionInfo.Version}");
 
 commandApp.Configure(Log.Logger);
 


### PR DESCRIPTION
Output Version instead of ProductVersion to the console at startup.