### PR TITLE
ci: publish the NuGet package as an artifact

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -45,3 +45,8 @@ jobs:
         with:
           name: test-reports
           path: artifacts/test-reports
+      - name: 'Save NuGet packages'
+        uses: actions/upload-artifact@v4
+        with:
+          name: packages
+          path: artifacts/packages

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -21,9 +21,9 @@ class Build : NukeBuild
     [Solution]
     readonly Solution Solution;
 
-    readonly AbsolutePath ArtifactsDirectory = RootDirectory / "artifacts";
-
     readonly AbsolutePath TestReportsDirectory = RootDirectory / "artifacts" / "test-reports";
+
+    readonly AbsolutePath PackagesDirectory = RootDirectory / "artifacts" / "packages";
 
     [PathVariable]
     readonly Tool dotnet;
@@ -142,7 +142,7 @@ class Build : NukeBuild
                 .SetNoBuild(true)
                 .SetConfiguration(Configuration)
                 .SetProject($"{Solution.Directory}/src/DotBump/DotBump.csproj")
-                .SetOutputDirectory(ArtifactsDirectory));
+                .SetOutputDirectory(PackagesDirectory));
         });
 
     Target Publish => t => t
@@ -150,7 +150,7 @@ class Build : NukeBuild
         .Executes(() =>
         {
             Log.Information("Publishing...");
-            var packagePath = $"{ArtifactsDirectory}/*.nupkg";
+            var packagePath = $"{PackagesDirectory}/*.nupkg";
 
             if (!IsLocalBuild)
             {


### PR DESCRIPTION
Publish the NuGet package as an artifact in the Beta Release build to make it available as a regular download.