### PR TITLE
ci: add initial release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+  workflow_dispatch:
+
+permissions:
+  packages: write
+  contents: read
+
+jobs:
+  ubuntu-latest:
+    name: ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: ./global.json
+      - name: 'Cache: .nuke/temp, ~/.nuget/packages'
+        uses: actions/cache@v4
+        with:
+          path: |
+            .nuke/temp
+            ~/.nuget/packages
+          key: ${{ runner.os }}-${{ hashFiles('**/global.json', '**/*.csproj', '**/Directory.Packages.props') }}
+      - name: 'Run: Compile'
+        run: ./build.cmd Compile
+        env:
+          NuGetApiKey: ${{ secrets.GITHUB_TOKEN }}
+          NuGetFeed: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
+          PackAndPublish: true
+      - name: 'Save test reports'
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-reports
+          path: artifacts/test-reports
+      - name: 'Save NuGet packages'
+        uses: actions/upload-artifact@v4
+        with:
+          name: packages
+          path: artifacts/packages


### PR DESCRIPTION
Add an initial release workflow. 

This is a copy of the beta release workflow, additional steps can be added once the workflow is a little bit clearer.


