### PR TITLE
ci: configure code coverage runsettings in build

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -117,7 +117,7 @@ class Build : NukeBuild
                         .SetProjectFile(test.Path)
                         .EnableNoBuild()
                         .SetConfiguration(Configuration)
-                        .SetDataCollector("XPlat Code Coverage")
+                        .SetSettingsFile($"{test.Directory}/coverlet.runsettings")
                         .SetResultsDirectory(TestReportsDirectory)
                         .SetLoggers($"html;logfilename={TestReportsDirectory}/testResults.html"));
                 }

--- a/test/DotBump.Tests/DotBump.Tests.csproj
+++ b/test/DotBump.Tests/DotBump.Tests.csproj
@@ -96,6 +96,10 @@
     <Content Include="xunit.runner.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <None Remove="coverlet.runsettings" />
+    <None Include="coverlet.runsettings">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/test/DotBump.Tests/coverlet.runsettings
+++ b/test/DotBump.Tests/coverlet.runsettings
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<RunSettings>
+    <DataCollectionRunSettings>
+        <DataCollectors>
+            <DataCollector friendlyName="XPlat code coverage">
+                <Configuration>
+                    <IncludeTestAssembly>false</IncludeTestAssembly>
+                    <Exclude>[Spectre.*]*,[*]Spectre.*</Exclude>
+                </Configuration>
+            </DataCollector>
+        </DataCollectors>
+    </DataCollectionRunSettings>
+</RunSettings>


### PR DESCRIPTION
Add runsettings that exclude Spectre, add the runsettings to the nuke DotNetTest call and remove the SetDataCollector option.

This seems to solve the issue of Spectre results showing up in the code coverage reports.