### PR TITLE
feat: adapt NuGet catalog logging

### DIFF
--- a/src/DotBump/Commands/BumpSettings.cs
+++ b/src/DotBump/Commands/BumpSettings.cs
@@ -18,7 +18,7 @@ internal abstract class BumpSettings : CommandSettings
     /// argument list which seemed to not be possible with the default Spectre approach and to pick it up as early as
     /// possible to configure logging.
     /// </summary>
-    [Description("Enable debug logging for troubleshooting")]
+    [Description("Enable debug logging for troubleshooting. Includes response data.")]
     [CommandOption("--debug")]
     [DefaultValue(false)]
     public bool Debug { get; set; }

--- a/src/DotBump/Commands/BumpTools/BumpToolsHandler.cs
+++ b/src/DotBump/Commands/BumpTools/BumpToolsHandler.cs
@@ -18,7 +18,7 @@ internal class BumpToolsHandler(
 {
     public async Task<BumpReport> HandleAsync(BumpType bumpType, string nugetConfigPath)
     {
-        logger.MethodStart(nameof(BumpSdkHandler), nameof(HandleAsync), bumpType);
+        logger.MethodStart(nameof(BumpToolsHandler), nameof(HandleAsync), bumpType);
 
         var manifest = toolFileService.GetToolsManifest();
         var bumpReport = new BumpReport(manifest, bumpType);
@@ -97,7 +97,7 @@ internal class BumpToolsHandler(
             toolFileService.SaveToolsManifest(manifest);
         }
 
-        logger.MethodReturn(nameof(BumpSdkHandler), nameof(HandleAsync), bumpReport);
+        logger.MethodReturn(nameof(BumpToolsHandler), nameof(HandleAsync), bumpReport);
 
         return bumpReport;
     }

--- a/src/DotBump/Commands/BumpTools/DataModel/Registrations/CatalogPage.cs
+++ b/src/DotBump/Commands/BumpTools/DataModel/Registrations/CatalogPage.cs
@@ -1,6 +1,7 @@
 // Copyright © 2025 Roby Van Damme.
 
 using System.Text.Json.Serialization;
+using Destructurama.Attributed;
 using DotBump.Common;
 
 namespace DotBump.Commands.BumpTools.DataModel.Registrations;
@@ -16,6 +17,7 @@ internal record CatalogPage
     [JsonPropertyName("count")]
     public int Count { get; init; }
 
+    [NotLogged]
     [JsonPropertyName("items")]
     public List<Package>?
         Items


### PR DESCRIPTION
Exclude the list of packages from the log output and indicate response data may be present in the log.

Also fix the BumpToolsHandler log.