### PR TITLE
fix: fix tool package url

### DIFF
--- a/src/DotBump/Commands/BumpTools/NuGetClient.cs
+++ b/src/DotBump/Commands/BumpTools/NuGetClient.cs
@@ -61,7 +61,8 @@ internal sealed class NuGetClient(HttpClient httpClient, ILogger logger) : INuGe
         ArgumentException.ThrowIfNullOrWhiteSpace(registrationBaseUrl);
         ArgumentException.ThrowIfNullOrWhiteSpace(packageId);
 
-        var packageUrl = new Uri(registrationBaseUrl + packageId + "/index.json");
+        // NOTE: it probably makes sense to use the PackageDisplayMetadataUriTemplate here instead to avoid future problems?
+        var packageUrl = new Uri(registrationBaseUrl.TrimEnd('/') + "/" + packageId + "/index.json");
         try
         {
             var result = await httpClient.GetStringAsync(packageUrl).ConfigureAwait(false);


### PR DESCRIPTION
Fix the package URL issue that popped up in the latest dependency update and build.

There is an issue with a double slash in the tool package URL which seems to only fail in some circumstances, in this case in GitHub actions. Fixed it by trimming trailing slashes in the registrationBaseUrl. 
Will add an issue to review since it might make sense to use a different URL from the service index.

Closes #49 